### PR TITLE
Feature/create post

### DIFF
--- a/app/src/main/java/com/cupcake/jobsfinder/data/repository/Repository.kt
+++ b/app/src/main/java/com/cupcake/jobsfinder/data/repository/Repository.kt
@@ -1,4 +1,5 @@
 package com.cupcake.jobsfinder.data.repository
 
 interface Repository {
+	suspend fun createPost(content: String): Boolean
 }

--- a/app/src/main/java/com/cupcake/jobsfinder/data/repository/RepositoryImpl.kt
+++ b/app/src/main/java/com/cupcake/jobsfinder/data/repository/RepositoryImpl.kt
@@ -1,3 +1,11 @@
 package com.cupcake.jobsfinder.data.repository
 
-class RepositoryImpl : Repository
+import kotlinx.coroutines.delay
+import javax.inject.Inject
+
+class RepositoryImpl: Repository {
+	override suspend fun createPost(content: String): Boolean {
+		delay(2000)
+		return true
+	}
+}

--- a/app/src/main/java/com/cupcake/jobsfinder/domain/usecase/CreatePostUseCase.kt
+++ b/app/src/main/java/com/cupcake/jobsfinder/domain/usecase/CreatePostUseCase.kt
@@ -1,0 +1,13 @@
+package com.cupcake.jobsfinder.domain.usecase
+
+import com.cupcake.jobsfinder.data.repository.Repository
+import javax.inject.Inject
+
+
+class CreatePostUseCase @Inject constructor(
+	private val repository: Repository
+) {
+	suspend operator fun invoke(content: String): Boolean {
+		return repository.createPost(content)
+	}
+}

--- a/app/src/main/java/com/cupcake/jobsfinder/ui/post/CreatePostUiState.kt
+++ b/app/src/main/java/com/cupcake/jobsfinder/ui/post/CreatePostUiState.kt
@@ -1,0 +1,7 @@
+package com.cupcake.jobsfinder.ui.post
+
+data class CreatePostUiState(
+    val content: String = "",
+    val isLoading: Boolean = false,
+    val error: String = ""
+)

--- a/app/src/main/java/com/cupcake/jobsfinder/ui/post/CreatePostViewModel.kt
+++ b/app/src/main/java/com/cupcake/jobsfinder/ui/post/CreatePostViewModel.kt
@@ -1,0 +1,49 @@
+package com.cupcake.jobsfinder.ui.post
+
+import androidx.lifecycle.viewModelScope
+import com.cupcake.jobsfinder.domain.usecase.CreatePostUseCase
+import com.cupcake.jobsfinder.ui.base.BaseViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class CreatePostViewModel @Inject constructor(
+    private val createPostUseCase: CreatePostUseCase,
+) : BaseViewModel() {
+
+    private val _postUiState = MutableStateFlow(CreatePostUiState())
+    val postUiState = _postUiState.asStateFlow()
+
+    fun createPost() {
+        viewModelScope.launch {
+            _postUiState.update { it.copy(isLoading = true) }
+            try {
+                val post = createPostUseCase(
+                    content = _postUiState.value.content
+                )
+                if (post) {
+                    onSuccessCreatePost()
+                }
+            } catch (e: Exception) {
+                onCreatePostError(e.message.toString())
+            }
+            _postUiState.update { it.copy(isLoading = false) }
+        }
+    }
+
+
+    private fun onSuccessCreatePost() {
+        // Add logic for successful post creation
+    }
+
+    private fun onCreatePostError(errorMessage: String) {
+        _postUiState.update {
+            it.copy(
+                isLoading = false,
+                error = errorMessage
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/cupcake/jobsfinder/ui/post/PostUiEvent.kt
+++ b/app/src/main/java/com/cupcake/jobsfinder/ui/post/PostUiEvent.kt
@@ -1,0 +1,5 @@
+package com.cupcake.jobsfinder.ui.post
+
+sealed interface PostUiEvent {
+    data class ClickPostEvent(val id: Int) : PostUiEvent
+}


### PR DESCRIPTION
Add CreatePost

This pull request adds the `CreatePostViewModel` class to handle the post creation functionality in the UI. The `CreatePostViewModel` is responsible for coordinating the interaction between the UI and the `CreatePostUseCase` in the domain layer.

Changes Made:

- Added the `CreatePostViewModel` class.
- Implemented the `createPost` function to handle post creation and handle success/error states.
- Added the `CreatePostUseCase` class.
- Implemented the `invoke` operator function, which takes the `content` of the post as a parameter and returns a `Boolean` indicating the success of the post creation.
- Added the UI state handling using `StateFlow`.
- Added the `PostUiEvent` sealed interface to represent post-related UI events.
- Implemented the `ClickPostEvent` data class as a subtype of `PostUiEvent` to handle click events on posts with specific IDs.

Please review and provide feedback. Thank you!
